### PR TITLE
Clarify that node-red must listen on port 443

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ ex: /alexa
 3) Create the model of your interest.
 4) In the endpoint section, just insert:
 ###### \<Node-RED endpoit\>/\<url-configured in configuration node\>
-ex: https://myNodeRed:1880/alexa
+ex: https://myNodeRed/alexa
 
-Note: SSL required.
+Note: SSL required and the node-red server must accept requests on port 443.
 
 
 ## (III) Nodes:


### PR DESCRIPTION
The current version of the readme shows an example where port 1880 is used. However, Alexa endpoint are required to listen to port 443. See https://developer.amazon.com/en-US/docs/alexa/custom-skills/host-a-custom-skill-as-a-web-service.html